### PR TITLE
fix: be more helpful on bad args

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,12 @@ func newRootCmd() *cobra.Command {
 		if len(args) < 1 || len(args) > 2 {
 			return fmt.Errorf("accepts 1 or 2 args, received %d", len(args))
 		}
+		if args[0] == "" {
+			return fmt.Errorf("oldCommit should not be empty")
+		}
+		if len(args) == 2 && args[1] == "" {
+			return fmt.Errorf("if provided, newCommit should not be empty")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
If you manually pass an empty string (`""`) for either argument, main will panic. I found this out because shellcheck likes double quotes around variables and I ran apidiff with an empty variable.

Before:
```bash
ace@ace-home-vm:~/go/src/github.com/joelanford/go-apidiff$ ../apidiff ""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x96b2bd]

ace@ace-home-vm:~/go/src/github.com/joelanford/go-apidiff$ ../apidiff "HEAD" ""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x96b2bd]
```

After:
```bash
ace@ace-home-vm:~/go/src/github.com/joelanford/go-apidiff$ ../apidiff ""
Error: oldCommit should not be empty
Usage:
  go-apidiff <oldCommit> [newCommit] [flags]
...

ace@ace-home-vm:~/go/src/github.com/joelanford/go-apidiff$ ../apidiff "HEAD" ""
Error: if provided, newCommit should not be empty
Usage:
  go-apidiff <oldCommit> [newCommit] [flags]
...
```