### PR TITLE
pkg/diff/run.go: reset worktree after loading packages

### DIFF
--- a/pkg/diff/run.go
+++ b/pkg/diff/run.go
@@ -187,6 +187,21 @@ func getPackages(wt git.Worktree, hash plumbing.Hash) (map[string]*packages.Pack
 			}
 		}
 	}
+
+	// Reset the worktree. Sometimes loading the packages can cause the
+	// worktree to become dirty. It seems like this occurs because package
+	// loading can change go.mod and go.sum.
+	//
+	// TODO(joelanford): If go-git starts to support checking out of specific
+	//   files we can update this to be less aggressive and only checkout
+	//   go.mod and go.sum instead of resetting the entire tree.
+	if err := wt.Reset(&git.ResetOptions{
+		Mode:   git.HardReset,
+		Commit: hash,
+	}); err != nil {
+		return nil, nil, fmt.Errorf("failed to hard reset to %v: %w", hash, err)
+	}
+
 	return selfPkgs, importPkgs, nil
 }
 


### PR DESCRIPTION
After loading Go packages, the go.mod and go.sum files are sometimes modified.
This causes subsequent checkouts of other commits to fail, which results in
the command failing to produce API differences.

This commit performs a hard reset on the worktree after the packages have been
loaded so that subsequent checkouts succeed. This should be safe because
go-apidiff checks to ensure that the tree is clean when the program starts.