### PR TITLE
add go releaser to release binaries to a tagged release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,22 @@
+env:
+  - GO111MODULE=on
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: go-apidiff 
+    main: .
+    binary: go-apidiff
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    targets:
+      - linux_amd64
+      - darwin_amd64
+    env:
+      - CGO_ENABLED=0
+release:
+  github:
+    owner: joelanford
+    name: go-apidiff
+


### PR DESCRIPTION
Hello Joe,

I would like to add this `.goreleaser.yml` which provides an easy way to push a tag and release binaries to the tagged github releases. Many go projects are using this for various purposes.

Instructions are as follows:
```
1. Install go releaser: https://goreleaser.com/install/
2. git tag -a v0.1.1 -m "Minor release"
3. goreleaser release
```

This will help in downloading the binaries directly instead of doing a `go get`.

Hope you will consider this.

Thanks,
Goutam Tadi.