### PR TITLE
action.yml: support go1.16+ 'go install'-style installations

### DIFF
--- a/.github/workflows/go-apidiff.yml
+++ b/.github/workflows/go-apidiff.yml
@@ -9,6 +9,6 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.15.x
+        go-version: 1.17.x
     - uses: ./
 

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,12 @@ runs:
           echo "*** Installing go-apidiff from source ***"
           go install .
         else
+          INSTALL_CMD="go install"
+          if [[ "$(go version | cut -d' ' -f3 | cut -d'.' -f2 | grep -o -E '[0-9]+' | head -1)" -lt "16" ]]; then
+            INSTALL_CMD="go get"
+          fi
           DIR=$(mktemp -d)
-          (cd ${DIR} && GO111MODULE=on go get github.com/joelanford/go-apidiff@${{ inputs.version }}) && rmdir ${DIR}
+          (cd ${DIR} && GO111MODULE=on ${INSTALL_CMD} github.com/joelanford/go-apidiff@${{ inputs.version }}) && rmdir ${DIR}
         fi
         set -x
         $(go env GOPATH)/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joelanford/go-apidiff
 
-go 1.15
+go 1.17
 
 require (
 	github.com/go-git/go-billy/v5 v5.0.0
@@ -9,4 +9,20 @@ require (
 	golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	golang.org/x/tools v0.0.0-20191004183538-27eeabb02079
+)
+
+require (
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=


### PR DESCRIPTION
In go versions <1.18, it is possible to use `go get <mod>@<version>` to compile and install Go binaries into $GOBIN.
In go versions >=1.16, it is possible to use `go install <mod>@<version>` to compile and install Go binaries into $GOBIN.

This PR adds support for the `go install` variant which is the only supported mechanism starting in Go 1.18. 