### PR TITLE
Add output: `semver-type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Skip automatic caching of go module directories (default: `false`)
 
 ### Outputs
 
-_(none)_
+#### `semver-type`
+
+Returns the type (patch, minor, major) of the sementic version that would be required if producing a release.
 
 ### Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Skip automatic caching of go module directories'
     required: false
     default: false
+outputs:
+  semver-type:
+    description: "Returns the type (patch, minor, major) of the sementic version that would be required if producing a release."
+    value: ${{ steps.go-apidiff.outputs.semver-type }}
 runs:
   using: 'composite'
   steps:
@@ -41,6 +45,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-go-apidiff
     - shell: bash
+      id: go-apidiff
       run: |
         if [[ "${{ github.repository }}" == "joelanford/go-apidiff" && "${{ inputs.version }}" == "latest" ]]; then
           echo "*** Installing go-apidiff from source ***"
@@ -54,4 +59,18 @@ runs:
           (cd ${DIR} && GO111MODULE=on ${INSTALL_CMD} github.com/joelanford/go-apidiff@${{ inputs.version }}) && rmdir ${DIR}
         fi
         set -x
-        $(go env GOPATH)/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }}
+        GOPATH=$(go env GOPATH)
+        set +e
+        OUTPUT=$($GOPATH/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }})
+        GOAPIDIFF_RC=$?
+        set -e
+        if [ $GOAPIDIFF_RC -eq 0 ]; then
+          if [ -z "$OUTPUT" ]; then
+            echo "semver-type=patch" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "semver-type=minor" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "semver-type=major" >> $GITHUB_OUTPUT
+        exit $GOAPIDIFF_RC


### PR DESCRIPTION
`semver-type` returns the type (patch, minor, major) of the sementic
version that would be required if producing a release.

This can be useful when we want to automatically label a PR with its
semver, which later can be used for automatic releases, etc.
