### PR TITLE
GHA: remove skip-cache input variable, update examples

### DIFF
--- a/.github/workflows/go-apidiff.yml
+++ b/.github/workflows/go-apidiff.yml
@@ -4,11 +4,11 @@ jobs:
   go-apidiff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v4
       with:
-        go-version: 1.18.x
+        go-version-file: go.mod
     - uses: ./
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Print compatible API changes (default: `true`)
 
 Path to root of git repository to compare (default: current working directory)
 
-#### `skip-cache`
-
-Skip automatic caching of go module directories (default: `false`)
-
 ### Outputs
 
 #### `semver-type`
@@ -50,12 +46,12 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
-        go-version: "1.18"
+        go-version-file: go.mod
     - uses: joelanford/go-apidiff@main
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,6 @@ inputs:
     description: 'Path to root of git repository to compare'
     required: false
     default: '.'
-  skip-cache:
-    description: 'Skip automatic caching of go module directories'
-    required: false
-    default: false
 outputs:
   semver-type:
     description: "Returns the type (patch, minor, major) of the sementic version that would be required if producing a release."
@@ -35,15 +31,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v3
-      if: ${{ inputs.skip-cache != 'true' }}
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-apidiff-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-apidiff
     - shell: bash
       id: go-apidiff
       run: |


### PR DESCRIPTION
Current versions of the setup-go action automatically setup Go caches automatically, so there is no need for us to do this anymore.

Remove the skip-cache variable, and update the example in the README to use a version of the setup-go action that automatically caches.