### PR TITLE
Add ability to ignore packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Version of go-apidiff to use (default: `latest`)
 
 Compare exported API differences in the imports of the repo (default: `false`)
 
+#### `ignore-list`
+
+Comma-separated list of packages prefixes to ignore (default: `''`)
+
 #### `print-compatible`
 
 Print compatible API changes (default: `true`)
@@ -80,6 +84,7 @@ Usage:
 Flags:
       --compare-imports    Compare exported API differences of the imports in the repo.
   -h, --help               help for go-apidiff
+  -i, --ignore strings     Ignore packages starting with prefix. Can be repeated.
       --print-compatible   Print compatible API changes
       --repo-path string   Path to root of git repository to compare (default "/home/myuser/myproject")
 ```

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Path to root of git repository to compare'
     required: false
     default: '.'
+  ignore-list:
+    description: 'Comma-separated list of packages prefixes to ignore'
+    required: false
+    default: ''
 outputs:
   semver-type:
     description: "Returns the type (patch, minor, major) of the sementic version that would be required if producing a release."
@@ -48,7 +52,7 @@ runs:
         set -x
         GOPATH=$(go env GOPATH)
         set +e
-        OUTPUT=$($GOPATH/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }})
+        OUTPUT=$($GOPATH/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }} --ignore=${{ inputs.ignore-list }} )
         GOAPIDIFF_RC=$?
         set -e
         if [ $GOAPIDIFF_RC -eq 0 ]; then

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ and HEAD is used for newCommit."`,
 	cmd.Flags().StringVar(&opts.RepoPath, "repo-path", cwd, "Path to root of git repository to compare")
 	cmd.Flags().BoolVar(&opts.CompareImports, "compare-imports", false, "Compare exported API differences of the imports in the repo. ")
 	cmd.Flags().BoolVar(&printCompatible, "print-compatible", false, "Print compatible API changes")
+	cmd.Flags().StringSliceVarP(&opts.IgnoreList, "ignore", "i", []string{}, "Ignore packages starting with prefix. Can be repeated.")
 
 	return cmd
 }


### PR DESCRIPTION
By passing the `--ignore` flag to go-apidiff it is now possible to ignore incompatible changes in a list of packages. This flag can be specified multiple times.

This is passed via the `ignore-list` input parameter in the github action and must be specified as a comma-separated list.

Fixes #35