### PR TITLE
docs: correct invalid default value in baseRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ commit, but not the old commit, you may not get accurate results.
 
 #### `base-ref`
 
-Base reference for API compatibility comparison (default: `origin/${GITHUB_BASE_REF}`)
+Base reference for API compatibility comparison (default: `github.event.pull_request.base.sha`)
 
 #### `version`
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ commit, but not the old commit, you may not get accurate results.
 
 #### `base-ref`
 
-Base reference for API compatibility comparison (default: `github.event.pull_request.base.sha`)
+Base reference for API compatibility comparison (default: `github.event.pull_request.base.sha` for PR  and `github.event.merge_group.base_sha` for merge queue)
 
 #### `version`
 


### PR DESCRIPTION
Base ref always need to be SHA. Using branch /refs as documented fails with errors.