### PR TITLE
fix: move build tags to file beginning before copyright header

### DIFF
--- a/pkg/diff/internal/osfs/os_posix.go
+++ b/pkg/diff/internal/osfs/os_posix.go
@@ -1,3 +1,6 @@
+//go:build !plan9 && !windows
+// +build !plan9,!windows
+
 /*
 Copyright 2021 Joe Lanford.
 
@@ -15,8 +18,6 @@ limitations under the License.
 
 NOTE: Originally copied from https://raw.githubusercontent.com/go-git/go-billy/d7a8afccaed297c30f8dff5724dbe422b491dd0d/osfs/os_posix.go
 */
-
-// +build !plan9,!windows
 
 package osfs
 

--- a/pkg/diff/internal/osfs/os_windows.go
+++ b/pkg/diff/internal/osfs/os_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 /*
 Copyright 2021 Joe Lanford.
 
@@ -15,8 +18,6 @@ limitations under the License.
 
 NOTE: Originally copied from https://raw.githubusercontent.com/go-git/go-billy/d7a8afccaed297c30f8dff5724dbe422b491dd0d/osfs/os_windows.go
 */
-
-// +build windows
 
 package osfs
 


### PR DESCRIPTION
## Summary
- Move build tags to the beginning of files, before copyright headers
- Add new `//go:build` syntax alongside legacy `// +build` syntax for compatibility

## Problem
Build tags were placed after copyright headers, causing them to be ignored by the Go compiler. This resulted in Windows cross-compilation errors where both `os_posix.go` and `os_windows.go` were compiled together, leading to duplicate declarations:

```
GOOS=windows go build .
# github.com/joelanford/go-apidiff/pkg/diff/internal/osfs
pkg/diff/internal/osfs/os_windows.go:50:16: method file.Lock already declared at pkg/diff/internal/osfs/os_posix.go:29:16
pkg/diff/internal/osfs/os_windows.go:65:16: method file.Unlock already declared at pkg/diff/internal/osfs/os_posix.go:36:16
pkg/diff/internal/osfs/os_windows.go:77:6: rename redeclared in this block
```

## Solution
According to Go's build tag specification, build constraints must be placed at the beginning of the file before any other comments. This fix moves the build tags to the proper location.