### PR TITLE
Add --exclude flag to skip packages from API comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Print compatible API changes (default: `true`)
 
 Path to root of git repository to compare (default: current working directory)
 
+#### `exclude`
+
+Patterns to exclude from API comparison (newline or comma-separated, relative to module root, supports `*` and `**` wildcards). A pattern without wildcards does prefix matching (e.g. `cmd` matches `cmd` and everything under it).
+
+Example:
+```yaml
+- uses: joelanford/go-apidiff@main
+  with:
+    exclude: |
+      cmd
+      examples
+      test*
+```
+
 ### Outputs
 
 #### `semver-type`
@@ -83,10 +97,11 @@ Usage:
   go-apidiff <oldCommit> [newCommit] [flags]
 
 Flags:
-      --compare-imports    Compare exported API differences of the imports in the repo.
-  -h, --help               help for go-apidiff
-      --print-compatible   Print compatible API changes
-      --repo-path string   Path to root of git repository to compare (default "/home/myuser/myproject")
+      --compare-imports        Compare exported API differences of the imports in the repo.
+      --exclude stringArray    Exclude packages matching the given pattern (relative to module root, supports * and ** wildcards)
+  -h, --help                   help for go-apidiff
+      --print-compatible       Print compatible API changes
+      --repo-path string       Path to root of git repository to compare (default "/home/myuser/myproject")
 ```
 
 ## Example output

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Path to root of git repository to compare'
     required: false
     default: '.'
+  exclude:
+    description: 'Patterns to exclude from API comparison (newline or comma-separated, relative to module root, supports * and ** wildcards)'
+    required: false
+    default: ''
 outputs:
   semver-type:
     description: "Returns the type (patch, minor, major) of the sementic version that would be required if producing a release."
@@ -50,8 +54,23 @@ runs:
         fi
         set -x
         GOPATH=$(go env GOPATH)
+        EXCLUDE_FLAGS=""
+        if [[ -n "${{ inputs.exclude }}" ]]; then
+          echo "${{ inputs.exclude }}" | tr ',' '\n' | while IFS= read -r line; do
+            line="$(echo "$line" | xargs)"
+            if [[ -n "$line" ]]; then
+              echo "$line" >> "$RUNNER_TEMP/go-apidiff-excludes"
+            fi
+          done
+          if [[ -f "$RUNNER_TEMP/go-apidiff-excludes" ]]; then
+            while IFS= read -r pattern; do
+              EXCLUDE_FLAGS="$EXCLUDE_FLAGS --exclude=$pattern"
+            done < "$RUNNER_TEMP/go-apidiff-excludes"
+            rm -f "$RUNNER_TEMP/go-apidiff-excludes"
+          fi
+        fi
         set +e
-        OUTPUT=$($GOPATH/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }})
+        OUTPUT=$($GOPATH/bin/go-apidiff ${{ inputs.base-ref }} --compare-imports=${{ inputs.compare-imports }} --print-compatible=${{ inputs.print-compatible }} --repo-path=${{ inputs.repo-path }} $EXCLUDE_FLAGS)
         GOAPIDIFF_RC=$?
         set -e
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/main.go
+++ b/main.go
@@ -58,6 +58,10 @@ By default, it compares just the module itself and prints only incompatible
 changes. However it can be configured to print compatible changes and to search
 for API incompatibilities in the dependency changes of the repository.
 
+Packages can be excluded from comparison using the --exclude flag. Patterns are
+relative to the module root and support * (single segment) and ** (zero or more
+segments) wildcards. A pattern without wildcards does prefix matching.
+
 When used with just one argument, the passed argument is used for oldCommit,
 and HEAD is used for newCommit."`,
 		Args: checkArgs,
@@ -93,6 +97,7 @@ and HEAD is used for newCommit."`,
 	cmd.Flags().StringVar(&opts.RepoPath, "repo-path", cwd, "Path to root of git repository to compare")
 	cmd.Flags().BoolVar(&opts.CompareImports, "compare-imports", false, "Compare exported API differences of the imports in the repo. ")
 	cmd.Flags().BoolVar(&printCompatible, "print-compatible", false, "Print compatible API changes")
+	cmd.Flags().StringArrayVar(&opts.ExcludePaths, "exclude", nil, "Exclude packages matching the given pattern (relative to module root, supports * and ** wildcards)")
 
 	return cmd
 }

--- a/pkg/diff/run.go
+++ b/pkg/diff/run.go
@@ -17,10 +17,12 @@ limitations under the License.
 package diff
 
 import (
+	"bufio"
 	"fmt"
 	"go/types"
 	"os"
 	"path/filepath"
+	pathpkg "path"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -37,6 +39,7 @@ type Options struct {
 	OldCommit      string
 	NewCommit      string
 	CompareImports bool
+	ExcludePaths   []string
 }
 
 func Run(opts Options) (*Diff, error) {
@@ -97,12 +100,12 @@ func Run(opts Options) (*Diff, error) {
 		}
 	}()
 
-	selfOld, importsOld, err := getPackages(*wt, *oldHash)
+	selfOld, importsOld, err := getPackages(*wt, *oldHash, opts.ExcludePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get packages from old commit %q (%s): %w", opts.OldCommit, oldHash, err)
 	}
 
-	selfNew, importsNew, err := getPackages(*wt, *newHash)
+	selfNew, importsNew, err := getPackages(*wt, *newHash, opts.ExcludePaths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get packages from new commit %q (%s): %w", opts.NewCommit, newHash, err)
 	}
@@ -192,7 +195,7 @@ func getHashes(repo *git.Repository, oldRev, newRev plumbing.Revision) (*plumbin
 	return oldCommitHash, newCommitHash, nil
 }
 
-func getPackages(wt git.Worktree, hash plumbing.Hash) (map[string]*packages.Package, map[string]*packages.Package, error) {
+func getPackages(wt git.Worktree, hash plumbing.Hash, excludePaths []string) (map[string]*packages.Package, map[string]*packages.Package, error) {
 	if err := wt.Checkout(&git.CheckoutOptions{Hash: hash, Force: true}); err != nil {
 		return nil, nil, err
 	}
@@ -201,6 +204,11 @@ func getPackages(wt git.Worktree, hash plumbing.Hash) (map[string]*packages.Pack
 	}
 	if err := wt.Reset(&git.ResetOptions{Commit: hash, Mode: git.HardReset}); err != nil {
 		return nil, nil, err
+	}
+
+	modulePath, err := getModulePath(wt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read module path: %w", err)
 	}
 
 	goFlags := "-mod=readonly"
@@ -223,6 +231,9 @@ func getPackages(wt git.Worktree, hash plumbing.Hash) (map[string]*packages.Pack
 	for _, pkg := range pkgs {
 		// skip internal packages since they do not contain public APIs
 		if strings.HasSuffix(pkg.PkgPath, "/internal") || strings.Contains(pkg.PkgPath, "/internal/") {
+			continue
+		}
+		if isExcluded(pkg.PkgPath, modulePath, excludePaths) {
 			continue
 		}
 		selfPkgs[pkg.PkgPath] = pkg
@@ -257,4 +268,107 @@ func checkoutRef(wt git.Worktree, ref plumbing.Reference) (err error) {
 		return wt.Checkout(&git.CheckoutOptions{Hash: ref.Hash()})
 	}
 	return wt.Checkout(&git.CheckoutOptions{Branch: ref.Name()})
+}
+
+// getModulePath reads go.mod from the worktree root and returns the module path.
+func getModulePath(wt git.Worktree) (string, error) {
+	goModPath := filepath.Join(wt.Filesystem.Root(), "go.mod")
+	f, err := os.Open(goModPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open go.mod: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading go.mod: %w", err)
+	}
+	return "", fmt.Errorf("module directive not found in go.mod")
+}
+
+// isExcluded checks whether a package path should be excluded based on the
+// configured exclude patterns. It strips the module prefix from the package
+// path to get a module-relative path, then checks each pattern.
+func isExcluded(pkgPath, modulePath string, excludePaths []string) bool {
+	if len(excludePaths) == 0 {
+		return false
+	}
+
+	// Get the path relative to the module root
+	relPath := pkgPath
+	if pkgPath == modulePath {
+		relPath = "."
+	} else if strings.HasPrefix(pkgPath, modulePath+"/") {
+		relPath = strings.TrimPrefix(pkgPath, modulePath+"/")
+	} else {
+		// Not a module package, don't exclude
+		return false
+	}
+
+	for _, pattern := range excludePaths {
+		if matchPattern(pattern, relPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPattern checks if path matches the given pattern. Patterns are split
+// by "/" and matched segment-by-segment. "*" matches any single path segment
+// (using path.Match), "**" matches zero or more complete path segments.
+// A pattern without wildcards does prefix matching: "cmd" matches "cmd",
+// "cmd/tool", "cmd/tool/sub", etc.
+func matchPattern(pattern, path string) bool {
+	// Patterns without wildcards do prefix matching
+	if !strings.ContainsAny(pattern, "*?[") {
+		return path == pattern || strings.HasPrefix(path, pattern+"/")
+	}
+
+	patternParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(path, "/")
+
+	return matchParts(patternParts, pathParts)
+}
+
+func matchParts(patternParts, pathParts []string) bool {
+	if len(patternParts) == 0 {
+		return len(pathParts) == 0
+	}
+
+	seg := patternParts[0]
+
+	if seg == "**" {
+		restPattern := patternParts[1:]
+		// When "**" is the last pattern element (no following segments),
+		// it requires at least one path segment (e.g., cmd/** does not
+		// match cmd itself). Otherwise, it matches zero or more segments
+		// (e.g., **/generated matches generated at root).
+		start := 0
+		if len(restPattern) == 0 {
+			start = 1
+		}
+		for i := start; i <= len(pathParts); i++ {
+			if matchParts(restPattern, pathParts[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if len(pathParts) == 0 {
+		return false
+	}
+
+	matched, err := pathpkg.Match(seg, pathParts[0])
+	if err != nil || !matched {
+		return false
+	}
+
+	return matchParts(patternParts[1:], pathParts[1:])
 }


### PR DESCRIPTION
## Summary

- Add a repeatable `--exclude` CLI flag (`StringArrayVar`) to exclude packages from API compatibility checks using glob patterns relative to the module root
- Add a corresponding `exclude` input to the GitHub Action that accepts newline or comma-separated patterns
- Support `*` (single path segment) and `**` (zero or more segments) wildcards; patterns without wildcards do prefix matching (e.g. `cmd` matches `cmd` and everything under it)
- Document the new flag and action input in README.md

Fixes #35 

🤖 Generated with [Claude Code](https://claude.com/claude-code)